### PR TITLE
Allow to reuse/set ZMQ context used by Mongrel2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ rdoc
 pkg
 
 ## PROJECT::SPECIFIC
+
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -39,8 +39,6 @@ rescue LoadError
   end
 end
 
-task :test => :check_dependencies
-
 task :default => :test
 
 require 'rake/rdoctask'

--- a/lib/m2r.rb
+++ b/lib/m2r.rb
@@ -1,3 +1,15 @@
+
+module Mongrel2
+  class << self
+    attr_writer :zmq_context
+
+    def zmq_context(threads = 1)
+      @zmq_context ||= ZMQ::Context.new(threads)
+    end
+  end
+end
+
 require 'connection'
 require 'request'
 require 'handler'
+

--- a/m2r.gemspec
+++ b/m2r.gemspec
@@ -44,26 +44,13 @@ Gem::Specification.new do |s|
   s.summary = %q{Mongrel2 interface and handler library for JRuby}
   s.test_files = [
     "test/helper.rb",
-     "test/test_m2r.rb"
+    "test/test_m2r.rb",
+    "test/test_connection.rb"
   ]
 
-  if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
-    s.specification_version = 3
-
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<ffi>, [">= 0"])
-      s.add_runtime_dependency(%q<ffi-rzmq>, [">= 0"])
-      s.add_runtime_dependency(%q<json>, [">= 0"])
-    else
-      s.add_dependency(%q<ffi>, [">= 0"])
-      s.add_dependency(%q<ffi-rzmq>, [">= 0"])
-      s.add_dependency(%q<json>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<ffi>, [">= 0"])
-    s.add_dependency(%q<ffi-rzmq>, [">= 0"])
-    s.add_dependency(%q<json>, [">= 0"])
-  end
+  s.add_dependency(%q<ffi>, [">= 0"])
+  s.add_dependency(%q<ffi-rzmq>, [">= 0"])
+  s.add_dependency(%q<json>, [">= 0"])
+  s.add_development_dependency("rake", [">= 0.9.2"])
 end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,6 @@
 require 'rubygems'
-require 'test/unit'
-require 'shoulda'
+require 'minitest/autorun'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'm2r'
-
-class Test::Unit::TestCase
-end

--- a/test/test_connection.rb
+++ b/test/test_connection.rb
@@ -1,0 +1,20 @@
+require 'helper'
+
+class TestConnection < MiniTest::Unit::TestCase
+  def test_receive_message
+    request_addr = "inproc://requests"
+    response_addr = "inproc://responses"
+
+    push = Mongrel2.zmq_context.socket(ZMQ::PUSH)
+    assert_equal 0, push.bind(request_addr), "Could not bind push socket in tests"
+
+    sub = Mongrel2.zmq_context.socket(ZMQ::SUB)
+    assert_equal 0, sub.bind(response_addr), "Could not bind sub socket in tests"
+
+    connection = Mongrel2::Connection.new("a65c2d89-96ee-4bc9-971e-59b38ae24645", request_addr, response_addr)
+
+    push.send_string("1c5fd481-1121-49d8-a706-69127975db1a ebb407b2-49aa-48a5-9f96-9db121051484 / 2:{},0:,", ZMQ::NOBLOCK)
+
+    assert_instance_of Mongrel2::Request, connection.recv
+  end
+end

--- a/test/test_m2r.rb
+++ b/test/test_m2r.rb
@@ -1,7 +1,14 @@
 require 'helper'
 
-class TestM2r < Test::Unit::TestCase
-  should "probably rename this file and start testing for real" do
-    flunk "hey buddy, you should probably rename this file and start testing for real"
+class TestM2r < MiniTest::Unit::TestCase
+  def test_mongrel2_context_getter
+    Mongrel2.singleton_class.class_eval { @zmq_context = nil } # hack
+    assert_instance_of ZMQ::Context, Mongrel2.zmq_context
+  end
+
+  def test_mongrel2_context_setter
+    ctx = ZMQ::Context.new(2)
+    Mongrel2.zmq_context = ctx
+    assert_equal ctx, Mongrel2.zmq_context
   end
 end


### PR DESCRIPTION
As stated in: http://zguide.zeromq.org/page:all#Getting-the-Context-Right : "You should create and use exactly one context in your process"

Sometimes the programmer might want to create the Context itself and let
the handler use it. It can be done in two ways:

a) setting `Mongrel2.zmq_context`
b) providing it as a dependency when creating new Connection:

``` ruby
Mongrel2::Connection.new(sender_id, pull_addr, pub_addr, context)
```

But most people do not have such needs so by default we create our own
context with 1 thread for IO.
