### PR TITLE
Don't modify http headers when replying.

### DIFF
--- a/example/lobster.ru
+++ b/example/lobster.ru
@@ -13,5 +13,6 @@ require 'rack/lobster'
 require './rack_handler'
 
 use Rack::ShowExceptions
-Rack::Handler::Mongrel2.run Rack::Lobster.new
+use Rack::ContentLength
 
+Rack::Handler::Mongrel2.run Rack::Lobster.new

--- a/lib/m2r/connection.rb
+++ b/lib/m2r/connection.rb
@@ -94,7 +94,6 @@ module M2R
 
     private
     def http_response(body, code, headers)
-      headers['Content-Length'] = body.size
       headers_s = headers.map{|k, v| "%s: %s" % [k,v]}.join("\r\n")
 
       "HTTP/1.1 #{code} #{StatusMessage[code.to_i]}\r\n#{headers_s}\r\n\r\n#{body}"


### PR DESCRIPTION
Responsibility for applying headers is in the layer above connection
proxy to mongrel - in http libraries like Rack or Webmachine.
