### PR TITLE
Change Connection constructor to take sockets

### DIFF
--- a/example/rack_handler.rb
+++ b/example/rack_handler.rb
@@ -7,7 +7,7 @@ module Rack
   module Handler
     class Mongrel2
       def self.run(app, receive = "tcp://127.0.0.1:9997", send = "tcp://127.0.0.1:9996")
-        connection = M2R::Connection.new(SecureRandom.uuid, receive, send)
+        connection = M2R::Connection.for(SecureRandom.uuid, receive, send)
         @running   = true
         trap("SIGINT") { @running = false }
 

--- a/lib/m2r/connection.rb
+++ b/lib/m2r/connection.rb
@@ -2,13 +2,21 @@ require 'm2r'
 
 module M2R
   class Connection
-    def initialize(sender_id, request_addr, response_addr, context = M2R.zmq_context)
-      @request_socket = context.socket(ZMQ::PULL)
-      @request_socket.connect(request_addr)
 
-      @response_socket = context.socket(ZMQ::PUB)
-      @response_socket.connect(response_addr)
-      @response_socket.setsockopt(ZMQ::IDENTITY, sender_id)
+    def initialize(request_socket, response_socket)
+      @request_socket  = request_socket
+      @response_socket = response_socket
+    end
+
+    def self.for(sender_id, request_addr, response_addr, context = M2R.zmq_context)
+      request_socket = context.socket(ZMQ::PULL)
+      request_socket.connect(request_addr)
+
+      response_socket = context.socket(ZMQ::PUB)
+      response_socket.connect(response_addr)
+      response_socket.setsockopt(ZMQ::IDENTITY, sender_id)
+
+      new(request_socket, response_socket)
     end
 
     def receive

--- a/lib/m2r/handler.rb
+++ b/lib/m2r/handler.rb
@@ -8,7 +8,7 @@ module M2R
     end
 
     def self.for(sender_uuid, subscribe_address, publish_address)
-      new(Connection.new(sender_uuid, subscribe_address, publish_address))
+      new(Connection.for(sender_uuid, subscribe_address, publish_address))
     end
 
     # Callback for when the handler is waiting for a request

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -11,7 +11,7 @@ class ConnectionTest < MiniTest::Unit::TestCase
     sub = M2R.zmq_context.socket(ZMQ::SUB)
     assert_equal 0, sub.bind(response_addr), "Could not bind sub socket in tests"
 
-    connection = M2R::Connection.new("a65c2d89-96ee-4bc9-971e-59b38ae24645", request_addr, response_addr)
+    connection = M2R::Connection.for("a65c2d89-96ee-4bc9-971e-59b38ae24645", request_addr, response_addr)
 
     push.send_string("1c5fd481-1121-49d8-a706-69127975db1a ebb407b2-49aa-48a5-9f96-9db121051484 / 2:{},0:,", ZMQ::NOBLOCK)
 


### PR DESCRIPTION
The connection needs only request and response sockets as dependency
for proper working. For the most simple case `Connection` working
with one instance of _mongrel2_ can be created using `Connection.for`
method instead of `Connection.new` :

``` ruby
Connection.for(sender_id, request_addr, response_addr, context)
```

Standard method using

``` ruby
Connection.new(request_socket, response_socket)
```

is used for more general usecase. For example if someone wants the
handler to work with two _mongrel2_ instances the sockets can be
created "by hand" and connected to both mongrels.

That way we have standard constructor for general usage and
a method delegated for the most common case that takes identical arguments
as `initialize` did before this refactoring.
