### PR TITLE
Headers refactoring

### DIFF
--- a/example/rack_handler.rb
+++ b/example/rack_handler.rb
@@ -12,11 +12,9 @@ module Rack
         trap("SIGINT") { @running = false }
 
         while @running
-          puts "WAITING FOR REQUEST"
 
           req = connection.receive
           if req.disconnect?
-            puts "DICONNECT"
             next
           end
 
@@ -40,13 +38,7 @@ module Rack
           }
 
           env["SERVER_NAME"], env["SERVER_PORT"] = req.host.split(':', 2)
-          req.headers.each do |key, val|
-            unless key =~ /content_(type|length)/i
-              key = "HTTP_#{key.upcase}"
-            end
-            env[key] = val
-          end
-
+          req.headers.rackify(env)
           status, headers, rack_response = app.call(env)
           body = ""
           rack_response.each{|b| body << b}

--- a/example/rack_handler.rb
+++ b/example/rack_handler.rb
@@ -22,7 +22,7 @@ module Rack
 
           script_name = ENV["RACK_RELATIVE_URL_ROOT"] ||
             # PATTERN is like:  /test/(.*.json) or /handlertest
-            req.headers["PATTERN"].split('(', 2).first.gsub(/\/$/, '')
+            req.pattern.split('(', 2).first.gsub(/\/$/, '')
 
           env = {
             "rack.version"      => Rack::VERSION,
@@ -32,14 +32,14 @@ module Rack
             "rack.multithread"  => true,
             "rack.multiprocess" => true,
             "rack.run_once"     => false,
-            "mongrel2.pattern"  => req.headers["PATTERN"],
-            "REQUEST_METHOD"    => req.headers["METHOD"],
+            "mongrel2.pattern"  => req.pattern,
+            "REQUEST_METHOD"    => req.method,
             "SCRIPT_NAME"       => script_name,
-            "PATH_INFO"         => req.headers["PATH"].gsub(script_name, ''),
-            "QUERY_STRING"      => req.headers["QUERY"]
+            "PATH_INFO"         => req.path.gsub(script_name, ''),
+            "QUERY_STRING"      => req.query
           }
 
-          env["SERVER_NAME"], env["SERVER_PORT"] = req.headers["host"].split(':', 2)
+          env["SERVER_NAME"], env["SERVER_PORT"] = req.host.split(':', 2)
           req.headers.each do |key, val|
             unless key =~ /content_(type|length)/i
               key = "HTTP_#{key.upcase}"

--- a/lib/m2r/headers.rb
+++ b/lib/m2r/headers.rb
@@ -12,7 +12,7 @@ module M2R
     end
 
     def rackify(env = {})
-      inject(env) do |rack, (header, value)|
+      each do |header, value|
         key = "HTTP_" + header.upcase.gsub("-", "_")
         env[key] = value
       end

--- a/lib/m2r/headers.rb
+++ b/lib/m2r/headers.rb
@@ -1,0 +1,15 @@
+require 'delegate'
+
+module M2R
+  class Headers < DelegateClass(Hash)
+
+    def initialize(hash)
+      downcased = hash.inject({}) do |headers,(header,value)|
+        headers[header.downcase] = value
+        headers
+      end
+      super(downcased)
+    end
+
+  end
+end

--- a/lib/m2r/headers.rb
+++ b/lib/m2r/headers.rb
@@ -3,12 +3,22 @@ require 'delegate'
 module M2R
   class Headers < DelegateClass(Hash)
 
-    def initialize(hash)
+    def initialize(hash = {})
       downcased = hash.inject({}) do |headers,(header,value)|
         headers[header.downcase] = value
         headers
       end
       super(downcased)
+    end
+
+    def rackify(env = {})
+      inject(env) do |rack, (header, value)|
+        key = "HTTP_" + header.upcase.gsub("-", "_")
+        env[key] = value
+      end
+      env["CONTENT_LENGTH"] = env.delete("HTTP_CONTENT_LENGTH") if env.key?("HTTP_CONTENT_LENGTH")
+      env["CONTENT_TYPE"]   = env.delete("HTTP_CONTENT_TYPE")   if env.key?("HTTP_CONTENT_TYPE")
+      env
     end
 
   end

--- a/lib/m2r/request.rb
+++ b/lib/m2r/request.rb
@@ -1,17 +1,18 @@
 require 'm2r'
 require 'm2r/request/upload'
+require 'm2r/headers'
 
 module M2R
-  class Request
-    attr_reader :sender, :conn_id, :path, :headers, :body
-
-    include Upload
+  class BaseRequest
+    MongrelHeaders = %w(PATTERN METHOD PATH QUERY host).map(&:downcase).map(&:freeze).freeze
+    attr_reader :sender, :conn_id, :path, :headers, :body, :mongrel
 
     def initialize(sender, conn_id, path, headers, body)
+      @mongrel = {}
       @sender  = sender
       @conn_id = conn_id
       @path    = path
-      @headers = headers
+      @headers = parse_headers(headers)
       @body    = body
       @data    = MultiJson.load(@body) if json?
     end
@@ -21,13 +22,8 @@ module M2R
 
       headers, rest = TNetstring.parse(rest)
       body, _       = TNetstring.parse(rest)
-      headers       = MultiJson.load(headers)
-
+      headers       = Headers.new MultiJson.load(headers)
       self.new(sender, conn_id, path, headers, body)
-    end
-
-    def method
-      headers['METHOD']
     end
 
     def disconnect?
@@ -35,8 +31,47 @@ module M2R
     end
 
     def close?
-      headers['VERSION']    == 'HTTP/1.0' ||
-      headers['connection'] == 'close'
+      http1_0? || connection_close?
+    end
+
+    def pattern
+      mongrel['pattern']
+    end
+
+    def method
+      mongrel['method']
+    end
+
+    def query
+      mongrel['query']
+    end
+
+    def host
+      mongrel['host']
+    end
+
+    def path
+      mongrel['path']
+    end
+
+    def header(header)
+      headers[header]
+    end
+
+    def version
+      header('version')
+    end
+
+    def connection
+      header('connection')
+    end
+
+    def http1_0?
+      header(version)    == 'HTTP/1.0'
+    end
+
+    def connection_close?
+      connection.downcase == 'close'
     end
 
     protected
@@ -45,5 +80,20 @@ module M2R
       method == 'JSON'
     end
 
+    def parse_headers(headers)
+      mongrel_headers.each do |header|
+        mongrel[header] = headers.delete(header)
+      end
+      return headers
+    end
+
+    def mongrel_headers
+      MongrelHeaders
+    end
+
+  end
+
+  class Request < BaseRequest
+    include Upload
   end
 end

--- a/lib/m2r/request.rb
+++ b/lib/m2r/request.rb
@@ -82,6 +82,7 @@ module M2R
 
     def parse_headers(headers)
       mongrel_headers.each do |header|
+        next unless headers.key?(header)
         mongrel[header] = headers.delete(header)
       end
       return headers

--- a/lib/m2r/request.rb
+++ b/lib/m2r/request.rb
@@ -4,7 +4,7 @@ require 'm2r/headers'
 
 module M2R
   class BaseRequest
-    MongrelHeaders = %w(PATTERN METHOD PATH QUERY host).map(&:downcase).map(&:freeze).freeze
+    MongrelHeaders = %w(pattern method path query).map(&:freeze).freeze
     attr_reader :sender, :conn_id, :path, :headers, :body, :mongrel
 
     def initialize(sender, conn_id, path, headers, body)
@@ -46,10 +46,6 @@ module M2R
       mongrel['query']
     end
 
-    def host
-      mongrel['host']
-    end
-
     def path
       mongrel['path']
     end
@@ -68,6 +64,10 @@ module M2R
 
     def http1_0?
       header(version)    == 'HTTP/1.0'
+    end
+
+    def host
+      header('host')
     end
 
     def connection_close?

--- a/lib/m2r/request/upload.rb
+++ b/lib/m2r/request/upload.rb
@@ -1,34 +1,40 @@
 module M2R
-  class Request
-    module Upload
-      StartHeader = "x-mongrel2-upload-start".freeze
-      DoneHeader  = "x-mongrel2-upload-done".freeze
+  module Upload
+    StartHeader = "x-mongrel2-upload-start".freeze
+    DoneHeader  = "x-mongrel2-upload-done".freeze
 
-      def upload?
-        headers.key?(upload_start_header)
-      end
+    def upload?
+      mongrel.key?(upload_start_header)
+    end
 
-      def upload_start?
-        upload? && !headers.key?(upload_done_header)
-      end
+    def upload_start?
+      upload? && !mongrel.key?(upload_done_header)
+    end
 
-      def upload_done?
-        upload? && headers.key?(upload_done_header)
-      end
+    def upload_done?
+      upload? && mongrel.key?(upload_done_header)
+    end
 
-      def upload_path
-        headers[upload_done_header]
-      end
+    def upload_path
+      mongrel[upload_done_header]
+    end
 
-      protected
+    def mongrel_headers
+      super + upload_headers
+    end
 
-      def upload_done_header
-        Upload::DoneHeader
-      end
+    protected
 
-      def upload_start_header
-        Upload::StartHeader
-      end
+    def upload_headers
+      [upload_done_header, upload_start_header]
+    end
+
+    def upload_done_header
+      DoneHeader
+    end
+
+    def upload_start_header
+      StartHeader
     end
   end
 end

--- a/test/handler_test.rb
+++ b/test/handler_test.rb
@@ -1,37 +1,38 @@
 require 'test_helper'
 
-class HandlerTest < MiniTest::Unit::TestCase
-  def test_lifecycle_for_disconnect
-    connection = stub(:receive => disconnect_request)
-    h = TestHandler.new(connection)
-    h.listen
-    assert_equal [:wait, :request, :disconnect], h.called_methods
-  end
+module M2R
+  class HandlerTest < MiniTest::Unit::TestCase
+    def test_lifecycle_for_disconnect
+      connection = stub(:receive => disconnect_request)
+      h = TestHandler.new(connection)
+      h.listen
+      assert_equal [:wait, :request, :disconnect], h.called_methods
+    end
 
-  def test_lifecycle_for_upload_start
-    connection = stub(:receive => upload_start_request)
-    h = TestHandler.new(connection)
-    h.listen
-    assert_equal [:wait, :request, :start], h.called_methods
-  end
+    def test_lifecycle_for_upload_start
+      connection = stub(:receive => upload_start_request)
+      h = TestHandler.new(connection)
+      h.listen
+      assert_equal [:wait, :request, :start], h.called_methods
+    end
 
-  def test_lifecycle_for_upload_done
-    connection = stub(:receive => upload_done_request, :reply => nil)
-    h = TestHandler.new(connection)
-    h.listen
-    assert_equal [:wait, :request, :done, :process, :after, :reply], h.called_methods
-  end
+    def test_lifecycle_for_upload_done
+      connection = stub(:receive => upload_done_request, :reply => nil)
+      h = TestHandler.new(connection)
+      h.listen
+      assert_equal [:wait, :request, :done, :process, :after, :reply], h.called_methods
+    end
 
-  def disconnect_request
-    M2R::Request.new("sender", "conn_id", "/path", {"METHOD" => "JSON"}, '{"type":"disconnect"}')
-  end
+    def disconnect_request
+      Request.new("sender", "conn_id", "/path", Headers.new({"METHOD" => "JSON"}), '{"type":"disconnect"}')
+    end
 
-  def upload_start_request
-    M2R::Request.new("sender", "conn_id", "/path", {"x-mongrel2-upload-start" => "/tmp/file"}, '')
-  end
+    def upload_start_request
+      Request.new("sender", "conn_id", "/path", Headers.new({"x-mongrel2-upload-start" => "/tmp/file"}), '')
+    end
 
-  def upload_done_request
-    M2R::Request.new("sender", "conn_id", "/path", {"x-mongrel2-upload-start" => "/tmp/file", "x-mongrel2-upload-done" => "/tmp/file"}, '')
+    def upload_done_request
+      Request.new("sender", "conn_id", "/path", Headers.new({"x-mongrel2-upload-start" => "/tmp/file", "x-mongrel2-upload-done" => "/tmp/file"}), '')
+    end
   end
 end
-

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -7,5 +7,23 @@ module M2R
       assert_equal "CT", headers['content-type']
       assert_equal "Ty", headers['type']
     end
+
+    def test_rackify
+      headers = Headers.new({
+        "Content-Type" => "CT",
+        "type" => "Ty",
+        "Accept-Charset" => "utf8",
+        "cOnTenT-LeNgTh" => "123"
+      })
+      env = {"rack.version" => [1,1]}
+      headers.rackify(env)
+      assert_equal({
+        "rack.version" => [1,1],
+        "CONTENT_TYPE" => "CT",
+        "HTTP_TYPE"    => "Ty",
+        "HTTP_ACCEPT_CHARSET" => "utf8",
+        "CONTENT_LENGTH" => "123"
+      }, env)
+    end
   end
 end

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module M2R
-  class HandlerTest < MiniTest::Unit::TestCase
+  class HeadersTest < MiniTest::Unit::TestCase
     def test_downcasing
       headers = Headers.new({"Content-Type" => "CT", "type" => "Ty"})
       assert_equal "CT", headers['content-type']

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+module M2R
+  class HandlerTest < MiniTest::Unit::TestCase
+    def test_downcasing
+      headers = Headers.new({"Content-Type" => "CT", "type" => "Ty"})
+      assert_equal "CT", headers['content-type']
+      assert_equal "Ty", headers['type']
+    end
+  end
+end


### PR DESCRIPTION
Normalize accessing them with downcased string. Expose mongrel2 headers as request methods. Remove such headers from the list.
